### PR TITLE
Fix notice typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 you may need to run this app as an administrator to perform backups correctly. you don't need to, but it's recommended so you won't encounter problems when backing up
 
 if you are going to:
-* right clck on the executable, and press "Run as Administrator"
+* right click on the executable, and press "Run as Administrator"
 
 ---
 ### how to use:


### PR DESCRIPTION
## Summary
- fix a typo in `README.md` where `clck` was missing an `i`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68403b9b923c832999f129c1ed9ac0cb